### PR TITLE
fix sg for ecs and alb

### DIFF
--- a/terraform/security_group.tf
+++ b/terraform/security_group.tf
@@ -22,10 +22,34 @@ resource "aws_security_group" "bischierge-front-security-group" {
     ipv6_cidr_blocks = ["::/0"]
   }
 
+  ingress {
+      from_port       = 80
+      to_port         = 80
+      protocol        = "tcp"
+      cidr_blocks     = ["0.0.0.0/0"]
+      ipv6_cidr_blocks     = ["::/0"]
+  }
+
+  ingress {
+      from_port       = 3000
+      to_port         = 3000
+      protocol        = "tcp"
+      cidr_blocks     = ["0.0.0.0/0"]
+      ipv6_cidr_blocks     = ["::/0"]
+  }
+
   egress {
     from_port        = 3000
     to_port          = 3000
     protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
     cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
@@ -44,7 +68,6 @@ resource "aws_security_group" "bischierge-back-security-group" {
     to_port         = 3000
     protocol        = "tcp"
     cidr_blocks     = ["0.0.0.0/0"]
-    security_groups = [aws_security_group.bischierge-front-security-group.id]
     self            = false
   }
 
@@ -53,10 +76,9 @@ resource "aws_security_group" "bischierge-back-security-group" {
     to_port         = 443
     protocol        = "tcp"
     cidr_blocks     = ["0.0.0.0/0"]
-    security_groups = [aws_security_group.bischierge-front-security-group.id]
     self            = false
   }
-  
+
 }
 
 #######################


### PR DESCRIPTION
backのsubnetはpublic必須のため、frontのsgを加える必要はない。

ALBの設定をinternal（内部ALB）にして、ドメインと紐づけて実験。

frontのsubnet上のインスタンスからcurlを打つ→正常にアクセス出来る
frontのsubnet上のインスタンスにあるDockerコンテナからcurlを打つ→正常にアクセス出来る
ホストマシンからcurlを打つ→正常にアクセス出来ない
ブラウザ上からアクセス→正常にアクセス出来ない
axios.$getにてアクセス→正常にアクセス出来ない

恐らく、axiosからのアクセスはVPC上のsubnetからアクセスしていない
恐らくブラウザでURLを入力するのと同じ？多分、nuxtのコードをコンパイルしてからブラウザ上で実行しているので

ALBのinternal（内部）設定だと、ALB自体にprivate ipしか付与されないため、axiosやブラウザ、ホストマシンからのアクセスが出来なかった
ALB のinternet（外部）設定だと、ALB自体にpublic ipが付与され、かつRoute53のドメインに紐づくためにaxiosやブラウザ、ホストマシンからアクセス出来た

→SPAにしているのでブラウザ上から実行している模様。

frontサブネットには80と3000のインバウンドルール・0のアウトバウンドルールが必須
　→ALBのhealthチェック
　→ECSのインスタンス登録に必要（0のアウトバウンドルール）