### PR TITLE
fix db char

### DIFF
--- a/back/config/database.yml
+++ b/back/config/database.yml
@@ -11,6 +11,7 @@
 #
 default:      &default
   adapter:    mysql2
+  charset:    utf8
   encoding:   utf8
   pool:       <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username:   <%= ENV.fetch('MYSQL_USER') { 'root' } %>


### PR DESCRIPTION
本番環境では、テーブル定義上、utf-8になっていなかったために英文字以外弾かれていたため修正